### PR TITLE
Fix decoder/rule syntax errors that prevent wazuh-analysisd from loading

### DIFF
--- a/wazuh/decoders/unifi_decoders.xml
+++ b/wazuh/decoders/unifi_decoders.xml
@@ -13,7 +13,7 @@
 
 <decoder name="unifi-cef">
   <prematch>CEF:0\|Ubiquiti\|UniFi</prematch>
-  <regex>^CEF:0\|Ubiquiti\|UniFi Network(?: Application)?\|([^|]*)\|([^|]*)\|([^|]*)\|([^|]*)\|(.*)$</regex>
+  <regex type="pcre2">^CEF:0\|Ubiquiti\|UniFi Network(?: Application)?\|([^|]*)\|([^|]*)\|([^|]*)\|([^|]*)\|(.*)$</regex>
   <order>unifi_device_version, unifi_event_id, unifi_event_name, unifi_severity, extra_data</order>
 </decoder>
 
@@ -34,13 +34,13 @@
 
 <!--
   UNIFIadmin: capture everything up to the next CEF key (word followed by =)
-  or end of line.  Uses <pcre2> (Wazuh 4.2+) for non-greedy matching so admin
-  names containing spaces are captured correctly.
+  or end of line.  Uses <regex type="pcre2"> (Wazuh 4.2+) for non-greedy
+  matching so admin names containing spaces are captured correctly.
 -->
 <decoder name="unifi-cef-admin">
   <parent>unifi-cef</parent>
   <prematch> UNIFIadmin=</prematch>
-  <pcre2> UNIFIadmin=(.+?)(?:\s+\w+=|$)</pcre2>
+  <regex type="pcre2"> UNIFIadmin=(.+?)(?:\s+\w+=|$)</regex>
   <order>srcuser</order>
 </decoder>
 

--- a/wazuh/rules/unifi_rules.xml
+++ b/wazuh/rules/unifi_rules.xml
@@ -105,7 +105,9 @@
   <!-- Threat Detected and Blocked enrichment -->
   <rule id="100120" level="10">
     <if_sid>100109</if_sid>
-    <if_srcip>10.0.0.0/8,172.16.0.0/12,192.168.0.0/16</if_srcip>
+    <srcip>10.0.0.0/8</srcip>
+    <srcip>172.16.0.0/12</srcip>
+    <srcip>192.168.0.0/16</srcip>
     <description>UniFi: Threat detected and blocked from internal source.</description>
     <group>unifi,security,syslog,internal,</group>
   </rule>


### PR DESCRIPTION
Two configuration errors prevented a fresh deploy on Wazuh 4.14.1 from starting `wazuh-analysisd` at all:

## 1. `<pcre2>...</pcre2>` is not a valid Wazuh decoder tag

The correct form for PCRE2 patterns in Wazuh is `<regex type="pcre2">...</regex>`. With `<pcre2>`, `wazuh-analysisd -t` fails:

```
ERROR: Invalid element 'pcre2' for decoder 'decoder'
CRITICAL: (1202): Configuration error at 'etc/decoders/unifi_decoders.xml'
```

This PR also fixes the main `unifi-cef` decoder's `<regex>` tag by declaring `type="pcre2"` explicitly, since it relies on a PCRE2-only non-capturing group `(?: Application)?`. Without the explicit type, OSRegex is used and rejects the pattern — this is the root cause reported in #1.

## 2. `<if_srcip>` with comma-joined CIDRs is not accepted on Wazuh 4.14

```
ERROR: (1237): Invalid ip address: '10.0.0.0/8,172.16.0.0/12,192.168.0.0/16'
```

Splitting into three sibling `<srcip>` tags on rule `100120` validates cleanly and matches the same internal address space.

## Verification

After these changes, on Wazuh 4.14.1:
- `/var/ossec/bin/wazuh-analysisd -t` → exit 0
- `wazuh-manager` restarts successfully
- `wazuh-logtest` decodes synthetic CEF lines and matches the specific rules (e.g. `Admin Accessed UniFi Network` → rule `100101`, `Admin Made Config Changes` → `100102`, `Threat Detected` → `100109`, `Device Offline` → `100104`).

Closes #1.