### PR TITLE
Document rule file load-order behavior and the etc/rules/ trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Documentation
+- **Rule file load-order warning**: Added a note to the deployment section explaining that `wazuh-analysisd` merges the stock ruleset and `etc/rules/` into one alphabetical-by-filename load order (directory of origin is ignored), that Wazuh's stock rule files are all digit-prefixed, and why `unifi_rules.xml`'s letter-leading name and self-contained anchors keep it safe from that trap — plus guidance for anyone renaming it or layering more custom rules on top.
+
 ### Verified
 - **Verified against official Ubiquiti docs** (February 2026): All decoders, rules, and event names cross-checked with the [UniFi System Logs & SIEM Integration](https://help.ui.com/hc/en-us/articles/33349041044119-UniFi-System-Logs) documentation and the [Traffic Flows](https://help.ui.com/hc/en-us/articles/32201256219799) page.
 - **UniFi Network Application 10.0.x** (latest: 10.0.162): CEF format unchanged (`CEF:0|Ubiquiti|UniFi Network|...`).

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ sudo cp wazuh/decoders/unifi_decoders.xml /var/ossec/etc/decoders/
 sudo cp wazuh/rules/unifi_rules.xml /var/ossec/etc/rules/
 ```
 
+> **Rule file load order matters.** `wazuh-analysisd` loads *every* rule file — both the built-in ruleset in `ruleset/rules/` and everything you drop in `etc/rules/` — into **one combined list sorted alphabetically by filename**, ignoring which directory a file actually came from (confirmed by reading `src/config/rules-config.c`: the sort compares basenames only, so `<rule_dir>` order in `ossec.conf` has no effect on load order). Every file in Wazuh's own stock ruleset is named `NNNN-description.xml` (`0010-rules_config.xml` ... `0999-malicious-ioc-rules.xml`), so a custom file whose name *starts with a digit* can sort ahead of a stock file it depends on and silently fail to attach — logged as `(7617)`/`(7619)`/`(7620)` "signature ID not found" warnings that read as if the referenced rule doesn't exist, when it actually just hasn't loaded yet.
+>
+> `unifi_rules.xml` is unaffected by that specific trap as shipped: every rule here chains from its own self-contained anchors (`100100`, `100200`, matched via `<decoded_as>`, not `<if_sid>1</if_sid>`), and because the filename starts with a letter, it naturally sorts after Wazuh's entire (digit-prefixed) stock ruleset. Keep this in mind if you customize:
+> - Don't rename this file to start with a digit (e.g. `0000_unifi_rules.xml`) unless you also make sure it still sorts after the stock ruleset — a `9999_`-style prefix keeps it last; a low prefix like `0000_` will not, and can break it.
+> - Any additional custom rule file that references these rule IDs (`100100`-`100234`) via `<if_sid>` needs to sort *after* `unifi_rules.xml` in the same combined, directory-agnostic order.
+> - After adding or renaming rule files, dry-run with `sudo /var/ossec/bin/wazuh-analysisd -t` before restarting — it runs the real parser without touching the live daemon — and check for `(7611)`/`(7617)`/`(7619)`/`(7620)` warnings.
+> - Wazuh caps pending parse warnings at 50 per file (`ERRORLIST_MAXSIZE`) and silently drops the oldest ones past that limit, so with many custom rules, a wall of ~50 warnings doesn't mean everything before them loaded fine — confirm what's actually attached via the Wazuh API (`GET /rules?filename=...`) or the dashboard's Rules view rather than trusting warning counts alone.
+
 ### 2. (Optional) Receive syslog on the manager
 
 If UniFi (or your SIEM) sends syslog **to the Wazuh manager**, add the snippet from `wazuh/ossec-unifi.conf.snippet` into `/var/ossec/etc/ossec.conf` inside `<ossec_config>`:


### PR DESCRIPTION
## Summary
- `wazuh-analysisd` merges the stock ruleset (`ruleset/rules/`) and custom rules (`etc/rules/`) into **one alphabetical-by-filename load order**, ignoring which `<rule_dir>` a file actually came from (confirmed by reading `src/config/rules-config.c` -- the sort compares basenames only, so `<rule_dir>` order in `ossec.conf` has no effect).
- Every file in Wazuh's own stock ruleset is named `NNNN-description.xml`, so a custom file whose name starts with a digit can sort ahead of a stock file it depends on and silently fail to attach, logged as `(7617)`/`(7619)`/`(7620)` warnings that read as if the referenced rule doesn't exist.
- `unifi_rules.xml` is unaffected as shipped: every rule chains off its own self-contained anchors (`100100`/`100200` via `<decoded_as>`, not `<if_sid>1</if_sid>`), and its letter-leading filename naturally sorts after Wazuh's entire (digit-prefixed) stock ruleset. This PR documents that so it stays true if the file is renamed or combined with more custom rules, plus points at `wazuh-analysisd -t` for safe dry-run testing and flags a related `ERRORLIST_MAXSIZE` warning-truncation gotcha.

Found and verified this while debugging a related load-order bug against a live Wazuh 4.14.5 manager and reading the relevant analysisd source.

## Test plan
- [x] Reviewed rendered markdown (blockquote + nested list) for correctness
- Documentation-only change, no XML/behavior changes